### PR TITLE
chore(README): updated to fix cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This tool **include:**
 
 ```bash
 git clone https://github.com/capture0x/XCTR-Hacking-Tools/
-cd xctr-hacking-tools
+cd XCTR-Hacking-Tools
 pip3 install -r requirements.txt
 ```
 


### PR DESCRIPTION
cd command was incorrect as it was in lowercase so copy & pasting the command lead to wrong results due to wrong capitalisation.